### PR TITLE
JAM-1585: Add S3 cache configuration, boto dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get -qq install -y --no-install-recommends \
 # Install TileStache dependencies
 WORKDIR /usr/src
 COPY . .
-RUN pip install -U -r requirements.txt
+RUN pip install -r requirements.txt
 
 # Configure nginx and Gunicorn
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-memcached
 mapbox-vector-tile==0.5.0
 Werkzeug==0.11.13
 gunicorn
+boto

--- a/tilestache.cfg.sample
+++ b/tilestache.cfg.sample
@@ -1,10 +1,10 @@
 {
     "cache":
     {
-        "name": "Test",
-        "path": "/tmp/stache",
-        "umask": "0000",
-        "gzip": ["pbf"]
+        "name": "S3",
+        "bucket": "billups-tile-cache",
+        "access": "YourAwsAccessId",
+        "secret": "YourAwsAccessSecret"
     },
     "layers":
     {


### PR DESCRIPTION
## Goal

Setup an S3 cache for serving MBTiles data more quickly.

## Testing

Create / update your local `tilestache.cfg` from the provided sample and rebuild the Docker container. You can validate that the cache is working by doing the following:

- Request a known tile coordinate (one you've seen before already)
- Now, update yoru config. Under the layers provider section, replace the actual `products.mbtiles` file with a fake file path. Remount your config to your docker container, if necessary.
- When the app goes to serve that location, it should serve the vector tile data (validating that it hit the cache)
- Request a tile coordinate you've never been to before.
- A SQL error should result.