### PR TITLE
JAM-1639:  Configure CORS based on nginx proxy header

### DIFF
--- a/tilestache.cfg.sample
+++ b/tilestache.cfg.sample
@@ -1,10 +1,9 @@
 {
     "cache":
     {
-        "name": "S3",
-        "bucket": "billups-tile-cache",
-        "access": "YourAwsAccessId",
-        "secret": "YourAwsAccessSecret"
+        "name": "Test",
+        "path": "/tmp/stache",
+        "umask": "0000"
     },
     "layers":
     {
@@ -14,8 +13,7 @@
             {
                 "name": "mbtiles",
                 "tileset": "data/mbtiles/products.mbtiles"
-            },
-            "allowed origin": "*"
+            }
         },
         "markers":
         {
@@ -23,8 +21,7 @@
             {
                 "name": "mbtiles",
                 "tileset": "data/mbtiles/markers.mbtiles"
-            },
-            "allowed origin": "*"
+            }
         }
     }
 }


### PR DESCRIPTION
## ~~! NOTE !~~

~~SR-868 will need to be merged for this to take effect. However, this still can be merged without it.~~

## Goal

Restrict CORS to only the billups domains. This is challenging because the boohma app supports dynamically generated subdomains, and [according to the W3 spec](https://www.w3.org/TR/2008/WD-access-control-20080912/#access-control-allow-origin), the `Access-Control-Allow-Origin` header only supports either a single wildcard, XOR a list of domains (i.e. *.edge.boohma.com is not supported).

My solution was to use nginx and add a helper function to the `TileStache` server to look for a custom header in the request and set the `Access-Control-Allow-Origin` accordingly. This should work fine for us since the ELB only exposes the nginx reverse proxy server, but it could still be spoofed if the client sends an `Origin` header with the correct domain (which would be the case anyway)

Oh well, better than nothing, I suppose.

## Testing

 Copy the `nginx/nginx.conf.sample` to `nginx/nginx.conf` and modify with the following lines:
```nginx
    # ... more configuration above ...

    upstream app_server {
        server unix:/var/gunicorn/gunicorn.sock fail_timeout=0;
    }

    # add this here...
    map $http_origin $cors_header {
        default "";
        "~^https?://.*\.local\.boohma\.com(:[0-9]+)?$" "$http_origin";
    }

    server {
        listen      9090 default deferred;
        server_name localhost;

        location / {
           # ... more headers here ... #
            proxy_set_header X-Proxy-Allow-Origin $cors_header; # add this here...
            proxy_pass       http://app_server;
        }
    }
}
```

Rebuild the docker image and container:
```
docker build -t tilestache .
docker-compose up -d
```

Configure your local DNS with an alias for localhost:
```
127.0.0.1  billups.local.boohma.com
```

Test using https://github.com/Billups/protomap. You will need to modify the `locdots.js` file by hand to set the tilestache URL. Try pointing protomap at your local TileStache host and then do the following:
- go to `http://localhost:<protomap_port>/locdots`, observe the JS console is indicating a CORS error for each XHR Request sent by the client and the dots do not show up.
- go to `http://billups.local.boohma.com:<protomap_port>/locdots`. Observe that the dots also show up and there are no CORS errors.